### PR TITLE
Add syft image workflow

### DIFF
--- a/.github/workflows/build-syft-image.yml
+++ b/.github/workflows/build-syft-image.yml
@@ -1,0 +1,51 @@
+name: Build syft image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - syft.Dockerfile
+    
+  pull_request:
+    branches:
+      - main
+    paths:
+      - syft.Dockerfile
+
+
+env:
+  REGISTRY: quay.io/redhat-appstudio
+  IMAGE_NAME: syft
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Extract version from Dockerfile
+      id: extract-version
+      run: echo "::set-output name=version::$(grep -oP '(?<=ARG syft_version=")[^"]*' syft.Dockerfile)"
+
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_NAME }}
+        tags: v${{ steps.extract-version.outputs.version }}
+        context: .
+        containerfiles: |
+            ./syft.Dockerfile
+
+    - name: Push to Quay
+      if: github.event_name == 'push'  # don't push image from PR
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
+        registry: ${{ env.REGISTRY }}
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "regexManagers": [
+    {
+      "fileMatch": ["^syft.Dockerfile$"],
+      "matchStrings": [
+        "ARG syft_version=[\"']?(?<currentValue>.+?)[\"']?\\s+"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "anchore/syft",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ]
+}

--- a/syft.Dockerfile
+++ b/syft.Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8:8.8-1032
+
+ARG syft_version="0.94.0"
+
+RUN dnf install -y https://github.com/anchore/syft/releases/download/v"${syft_version}"/syft_"${syft_version}"_linux_amd64.rpm && dnf clean all


### PR DESCRIPTION
This is about migrating our syft dockerfile from build-definitions to here. At the same time, the github workflow is set up for the building and pushing of the image. Automated updates will be handled by renovate bot.