### PR TITLE
Fix source image utils tagging

### DIFF
--- a/.github/workflows/source-build.yaml
+++ b/.github/workflows/source-build.yaml
@@ -46,7 +46,9 @@ jobs:
       uses: redhat-actions/buildah-build@v2
       with:
         image: ${{ env.IMAGE_NAME }}
-        tags: latest
+        tags: |
+          latest
+          ${{ github.sha }}
         context: ./source-container-build
         containerfiles: |
           ./source-container-build/Dockerfile

--- a/source-container-build/Makefile
+++ b/source-container-build/Makefile
@@ -5,10 +5,6 @@ IMAGE = quay.io/$(ORG)/build-definitions-source-image-build-utils:latest
 image:
 	podman build -t $(IMAGE) .
 
-.PHONY: push
-push:
-	podman push $(IMAGE)
-
 .PHONY: clean
 clean:
 	podman rmi $(IMAGE)


### PR DESCRIPTION
Previously, we tagged the image only with the 'latest' tag.

In quay.io, an image that doesn't have any tags cannot be pulled. By
pushing to the 'latest' tag, we would immediately invalidate the
previous image, breaking everyone who relied on the image.

Tag the image with the git commit sha to make sure every image will
always have at least one tag associated with it.