### PR TITLE
WIP: maybe the GH workflow will run from a fork?

### DIFF
--- a/.github/workflows/source-build.yaml
+++ b/.github/workflows/source-build.yaml
@@ -53,6 +53,10 @@ jobs:
         containerfiles: |
           ./source-container-build/Dockerfile
 
+    - name: test
+      script:
+        echo ${{ steps.build-image.outputs.tags }}
+
     - name: Push to Quay
       if: github.event_name == 'push'  # don't push image from PR
       uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/source-build.yaml
+++ b/.github/workflows/source-build.yaml
@@ -46,7 +46,9 @@ jobs:
       uses: redhat-actions/buildah-build@v2
       with:
         image: ${{ env.IMAGE_NAME }}
-        tags: latest
+        tags: |
+          latest
+          ${{ github.sha }}
         context: ./source-container-build
         containerfiles: |
           ./source-container-build/Dockerfile

--- a/source-container-build/Dockerfile
+++ b/source-container-build/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi:9.3-1361.1699548029
 
+# temp
+
 ARG BSI_VERSION=0.2.0
 ARG bsi_source=https://github.com/containers/BuildSourceImage/archive/refs/tags/v${BSI_VERSION}.tar.gz
 ARG patch0=0001-cleanup-directory-with-all-rpms-which-isn-t-used-any.patch


### PR DESCRIPTION
Previously, we tagged the image only with the 'latest' tag.

In quay.io, an image that doesn't have any tags cannot be pulled. By
pushing to the 'latest' tag, we would immediately invalidate the
previous image, breaking everyone who relied on the image.

Tag the image with the git commit sha to make sure every image will
always have at least one tag associated with it.