### PR TITLE
Don't build for and update the latest tag

### DIFF
--- a/.github/workflows/source-build.yaml
+++ b/.github/workflows/source-build.yaml
@@ -47,7 +47,6 @@ jobs:
       with:
         image: ${{ env.IMAGE_NAME }}
         tags: |
-          latest
           ${{ github.sha }}
         context: ./source-container-build
         containerfiles: |


### PR DESCRIPTION
The latest tag should not change at all. And subsequent builds for newer updates to source build should have their own tag. Then, any pipeline referencing the latest will not be broken. The new image reference can be updated by Renovate to the build-definitions.