### PR TITLE
feat: Support git submodules for source containers

### DIFF
--- a/source-container-build/app/source_build.py
+++ b/source-container-build/app/source_build.py
@@ -391,9 +391,37 @@ def make_source_archive(
     repo_info = get_repo_info(source_dir)
     name_sha = f"{repo_info['name']}-{repo_info['last_commit_sha']}"
     output_archive = f"{source_archive_dir}/{name_sha}.tar.gz"
-    git_cmd = ["git", "archive", "--prefix", name_sha + "/", "--output", output_archive, "HEAD"]
-    log.debug("Generate source archive %r", git_cmd)
-    run(git_cmd, check=True, cwd=source_dir)
+
+    stash_cmd = ["git", "stash"]
+    log.debug("Stashing any changes to working repo %r", stash_cmd)
+    run(stash_cmd, check=True, cwd=source_dir)
+
+    mtime_cmd = ["git", "show", "-s", "--format=%cI"]
+    log.debug("Collecting timestamp of the commit at HEAD %r", mtime_cmd)
+    mtime_process = run(mtime_cmd, check=True, cwd=source_dir, capture_output=True, text=True)
+    mtime = mtime_process.stdout.strip()
+
+    ls_cmd = ["git", "ls-files", "--recurse-submodules"]
+    log.debug("Generate source repo file list %r", ls_cmd)
+    git_process = run(ls_cmd, check=True, cwd=source_dir, capture_output=True, text=True)
+
+    tar_cmd = [
+        "tar",
+        "caf",
+        output_archive,
+        "--mtime",
+        mtime,
+        "--transform",
+        f"s,^,{name_sha}/,",
+        "-T-",
+    ]
+    log.debug("Generate source archive %r", tar_cmd)
+    run(tar_cmd, input=git_process.stdout.encode("utf-8"), check=True, cwd=source_dir)
+
+    pop_cmd = ["git", "stash", "pop"]
+    log.debug("Popping any stashed changes to working repo %r", pop_cmd)
+    run(pop_cmd, cwd=source_dir)
+
     log.info("add source archive directory to sources for bsi: %s", source_archive_dir)
     sib_dirs.extra_src_dirs.append(source_archive_dir)
 

--- a/source-container-build/app/test_source_build.py
+++ b/source-container-build/app/test_source_build.py
@@ -1015,6 +1015,16 @@ class TestBuildProcess(unittest.TestCase):
                 completed_proc.stdout = "https://githost/org/app.git"
                 return completed_proc
 
+            if run_cmd == ["git", "ls-files"]:
+                completed_proc = Mock()
+                completed_proc.stdout = "file.txt"
+                return completed_proc
+
+            if run_cmd == ["git", "show"]:
+                completed_proc = Mock()
+                completed_proc.stdout = "2024-03-20T21:57:06-04:00"
+                return completed_proc
+
             if run_cmd == ["skopeo", "inspect"]:
                 if parent_images:
                     dest_image = run_cmd[-1]


### PR DESCRIPTION
We found that the bootc project wished to use a git submodule to make managing their downstream repo's relationship to their upstream repo easy.

This change makes it so that the source archive of the git repository includes submodule content.