### PR TITLE
Add retry for image operations against registry

### DIFF
--- a/source-container-build/app/requirements-dev.txt
+++ b/source-container-build/app/requirements-dev.txt
@@ -5,6 +5,10 @@
 #    pip-compile --generate-hashes --output-file=requirements-dev.txt requirements-dev.in
 #
 
+backoff==2.2.1 \
+    --hash=sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba \
+    --hash=sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8
+    # via -r requirements.txt
 coverage[toml]==7.4.4 \
     --hash=sha256:00838a35b882694afda09f85e469c96367daa3f3f2b097d846a7216993d37f4c \
     --hash=sha256:0513b9508b93da4e1716744ef6ebc507aff016ba115ffe8ecff744d1322a7b63 \

--- a/source-container-build/app/requirements.in
+++ b/source-container-build/app/requirements.in
@@ -1,1 +1,2 @@
+backoff
 filetype

--- a/source-container-build/app/requirements.txt
+++ b/source-container-build/app/requirements.txt
@@ -5,6 +5,10 @@
 #    pip-compile --generate-hashes --output-file=requirements.txt requirements.in
 #
 
+backoff==2.2.1 \
+    --hash=sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba \
+    --hash=sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8
+    # via -r requirements.in
 filetype==1.2.0 \
     --hash=sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb \
     --hash=sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25

--- a/source-container-build/app/source_build.py
+++ b/source-container-build/app/source_build.py
@@ -175,11 +175,11 @@ def fetch_image_manifest(image: str) -> dict | None:
     """
     cmd = ["skopeo", "inspect", "--raw", f"docker://{image}"]
     proc = run(cmd, text=True, capture_output=True)
-    if proc.returncode != 0:
-        if proc.stderr.endswith(" manifest unknown"):
-            return None
-        raise CalledProcessError(proc.returncode, cmd, stderr=proc.stderr)
-    return json.loads(proc.stdout)
+    if proc.returncode == 0:
+        return json.loads(proc.stdout)
+    if proc.stderr.endswith(" manifest unknown"):
+        return None
+    proc.check_returncode()
 
 
 @backoff.on_exception(

--- a/source-container-build/app/test_source_build.py
+++ b/source-container-build/app/test_source_build.py
@@ -1396,7 +1396,8 @@ class TestFetchImageManifest(unittest.TestCase):
         self.assertIsNone(manifest)
 
     @patch("source_build.run")
-    def test_process_failure(self, run: MagicMock):
+    @patch("time.sleep")  # for backoff
+    def test_process_failure(self, sleep, run: MagicMock):
         run.return_value = Mock(returncode=1, stderr="something is wrong")
         with self.assertRaises(CalledProcessError) as ctx:
             _ = source_build.fetch_image_manifest(OUTPUT_BINARY_IMAGE)

--- a/source-container-build/app/test_source_build.py
+++ b/source-container-build/app/test_source_build.py
@@ -11,7 +11,7 @@ import unittest
 import zipfile
 from unittest.mock import call, patch, MagicMock, Mock
 from typing import Final
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError, CompletedProcess
 from dataclasses import dataclass
 from tempfile import mkdtemp, mkstemp
 
@@ -1398,7 +1398,7 @@ class TestFetchImageManifest(unittest.TestCase):
     @patch("source_build.run")
     @patch("time.sleep")  # for backoff
     def test_process_failure(self, sleep, run: MagicMock):
-        run.return_value = Mock(returncode=1, stderr="something is wrong")
+        run.return_value = CompletedProcess(["skopeo"], 1, "", "something is wrong")
         with self.assertRaises(CalledProcessError) as ctx:
             _ = source_build.fetch_image_manifest(OUTPUT_BINARY_IMAGE)
         e = ctx.exception


### PR DESCRIPTION
This PR includes a refactor to the original `registry_has_image`, that is helpful for determining when to retry.

https://issues.redhat.com/browse/STONEBLD-1873
