### PR TITLE
Reuse parent sources blobs for constructing source container

### DIFF
--- a/source-container-build/app/source_build.py
+++ b/source-container-build/app/source_build.py
@@ -585,9 +585,13 @@ class JSONBlob(Blob):
         super().__init__(*args, **kwargs)
         self._python_obj: dict | None = None
 
+    @staticmethod
+    def compact_json_dumps(data: Any) -> bytes:
+        return json.dumps(data, separators=(",", ":")).encode("utf-8")
+
     def save(self) -> Blob:
         """Write JSON string in text mode"""
-        self.raw_content = json.dumps(self.to_python, separators=(",", ":")).encode("utf-8")
+        self.raw_content = self.compact_json_dumps(self.to_python)
         return super().save()
 
     @property

--- a/source-container-build/app/test_oci_image.py
+++ b/source-container-build/app/test_oci_image.py
@@ -1,0 +1,152 @@
+import shutil
+import tempfile
+
+import unittest
+from source_build import Blob, OCIImage
+from test_source_build import create_blob, create_local_oci_image
+
+
+class TestBlob(unittest.TestCase):
+    """Test class Blob"""
+
+    def setUp(self):
+        self.image_dir = tempfile.mkdtemp()
+        self.descriptor = create_blob(self.image_dir, [b"binary data"], "config")
+        self.oci_image = OCIImage(self.image_dir)
+        self.blob = Blob(self.oci_image, self.descriptor)
+
+    def tearDown(self):
+        shutil.rmtree(self.image_dir)
+
+    def test___eq__(self):
+        tests: list[tuple[Blob | str, bool]] = [
+            ("an object", False),
+            (Blob(self.oci_image, self.descriptor.copy()), True),
+            (
+                Blob(
+                    self.oci_image,
+                    {
+                        "mediaType": self.descriptor["mediaType"],
+                        "digest": self.descriptor["digest"] + "1",
+                        "size": self.descriptor["size"],
+                    },
+                ),
+                False,
+            ),
+            (
+                Blob(
+                    self.oci_image,
+                    {
+                        "mediaType": self.descriptor["mediaType"],
+                        "digest": self.descriptor["digest"],
+                        "size": self.descriptor["size"],
+                        "annotations": {"type": "build"},
+                    },
+                ),
+                False,
+            ),
+        ]
+        for other_blob, expected in tests:
+            eq = self.blob == other_blob
+            self.assertEqual(expected, eq)
+
+    def test_raw_content(self):
+        content = self.blob.raw_content
+        self.assertTrue(isinstance(content, bytes))
+        self.assertEqual(id(content), id(self.blob.raw_content))
+
+    def test_to_python(self):
+        obj = self.blob.to_python
+        self.assertTrue(isinstance(obj, bytes))
+        self.assertEqual(id(obj), id(self.blob.raw_content))
+
+    def test_delete(self):
+        self.blob.delete()
+        self.assertFalse(self.blob.path.exists())
+
+    def test_save_content_has_not_been_read(self):
+        blob = Blob(self.oci_image, self.descriptor)
+        new_blob = blob.save()
+        self.assertEqual(id(blob), id(new_blob))
+
+    def test_save_content_is_updated(self):
+        self.blob.raw_content = b"ab"
+        new_blob = self.blob.save()
+        self.assertNotEqual(id(self.blob), id(new_blob))
+        self.assertEqual(b"ab", new_blob.path.read_bytes())
+        self.assertEqual(self.blob.descriptor["mediaType"], new_blob.descriptor["mediaType"])
+        self.assertNotEqual(self.blob.descriptor["digest"], new_blob.descriptor["digest"])
+        self.assertNotEqual(self.blob.descriptor["size"], new_blob.descriptor["size"])
+
+    def test_save_content_is_not_updated(self):
+        new_blob = self.blob.save()
+        self.assertEqual(id(self.blob), id(new_blob))
+        self.assertEqual(self.blob.descriptor["mediaType"], new_blob.descriptor["mediaType"])
+        self.assertEqual(self.blob.descriptor["digest"], new_blob.descriptor["digest"])
+        self.assertEqual(self.blob.descriptor["size"], new_blob.descriptor["size"])
+
+
+class TestManifest(unittest.TestCase):
+    """Test Manifest blob class"""
+
+    def setUp(self):
+        self.oci_image_path = tempfile.mkdtemp(prefix="test_manifest-")
+        create_local_oci_image(self.oci_image_path, [[b"123"]])
+        oci_image = OCIImage(self.oci_image_path)
+        self.manifest = oci_image.index.manifests()[0]
+
+    def tearDown(self):
+        shutil.rmtree(self.oci_image_path)
+
+    def test_save_when_no_change_to_both_config_and_layers(self):
+        # Save directly without any change to config or layers
+        new_manifest = self.manifest.save()
+        self.assertEqual(new_manifest, self.manifest)
+        self.assertEqual(id(new_manifest), id(self.manifest))
+
+    def test_save_when_config_is_updated(self):
+        self.manifest.config.to_python["architecture"] = "amd64"
+        new_manifest = self.manifest.save()
+        self.assertNotEqual(id(new_manifest), id(self.manifest))
+        self.assertEqual(new_manifest.config.to_python["architecture"], "amd64")
+
+    def test_save_when_layer_is_changed(self):
+        layer = self.manifest.layers[0]
+        layer.raw_content += b"new binary data"
+        new_manifest = self.manifest.save()
+        self.assertNotEqual(new_manifest, self.manifest)
+        self.assertNotEqual(id(new_manifest), id(self.manifest))
+        self.assertEqual(new_manifest.layers[0].raw_content, layer.raw_content)
+
+    def test_save_layer_without_blob_file(self):
+        self.manifest.layers[0].path.unlink()
+        with self.assertRaisesRegex(ValueError, expected_regex=""):
+            self.manifest.save()
+
+
+class TestIndex(unittest.TestCase):
+
+    def setUp(self):
+        self.oci_image_path = tempfile.mkdtemp(prefix="test-index-")
+        create_local_oci_image(self.oci_image_path, [[b"123"]])
+        self.oci_image = OCIImage(self.oci_image_path)
+
+    def tearDown(self):
+        shutil.rmtree(self.oci_image_path)
+
+    def test_get_manfiests(self):
+        manifests = self.oci_image.index.manifests()
+        self.assertEqual(len(manifests), 1)
+        self.assertTrue(manifests[0].path.exists())
+
+        manifests_2 = self.oci_image.index.manifests()
+        self.assertEqual(id(manifests), id(manifests_2))
+
+    def test_save(self):
+        manifest = self.oci_image.index.manifests()[0]
+        manifest.config.to_python["architecture"] = "amd64"
+        self.oci_image.index.save()
+
+        new_manifest = self.oci_image.index.manifests()[0]
+        self.assertNotEqual(manifest.descriptor["digest"], new_manifest.descriptor["digest"])
+        self.assertEqual(new_manifest.config.to_python["architecture"], "amd64")

--- a/source-container-build/app/test_source_build.py
+++ b/source-container-build/app/test_source_build.py
@@ -18,7 +18,7 @@ from tempfile import mkdtemp, mkstemp
 from pathlib import Path
 
 import source_build
-from source_build import BuildResult, DescriptorT, SourceImageBuildDirectories
+from source_build import BuildResult, DescriptorT, JSONBlob, SourceImageBuildDirectories
 
 import pytest
 
@@ -229,20 +229,20 @@ def create_local_oci_image(path: str, layers_data: list[list[bytes]]) -> None:
             },
         ],
     }
-    config_descriptor = create_blob(path, [json.dumps(config).encode("utf-8")], "config")
+    config_descriptor = create_blob(path, [JSONBlob.compact_json_dumps(config)], "config")
 
     manifest: ManifestT = {
         "schemaVersion": 2,
         "config": config_descriptor,
         "layers": [create_blob(path, data, "layer") for data in layers_data],
     }
-    manifest_descriptor = create_blob(path, [json.dumps(manifest).encode("utf-8")], "manifest")
+    manifest_descriptor = create_blob(path, [JSONBlob.compact_json_dumps(manifest)], "manifest")
 
     index_json = {
         "schemaVersion": 2,
         "manifests": [manifest_descriptor],
     }
-    Path(path, "index.json").write_text(json.dumps(index_json))
+    Path(path, "index.json").write_text(JSONBlob.compact_json_dumps(index_json).decode())
 
 
 class TestGetRepoInfo(unittest.TestCase):

--- a/source-container-build/app/test_source_build.py
+++ b/source-container-build/app/test_source_build.py
@@ -778,20 +778,18 @@ class TestBuildProcess(unittest.TestCase):
         dest_manifest = dest_image.index.manifests()[0]
         dest_config = dest_manifest.config
 
-        check_set = set(source_config.diff_ids) & set(dest_config.diff_ids)
-        self.assertListEqual(sorted(check_set), sorted(source_config.diff_ids))
+        n = len(source_config.diff_ids)
+        self.assertListEqual(dest_config.diff_ids[0:n], source_config.diff_ids)
 
-        source_history_created_by = set(history["created_by"] for history in source_config.history)
-        dest_history_created_by = set(history["created_by"] for history in dest_config.history)
-        check_set = source_history_created_by & dest_history_created_by
-        self.assertListEqual(sorted(check_set), sorted(source_history_created_by))
+        n = len(source_config.history)
+        self.assertListEqual(dest_config.history[0:n], source_config.history)
 
-        source_layers_digest = set(layer.descriptor["digest"] for layer in source_manifest.layers)
-        dest_layers_digest = set(layer.descriptor["digest"] for layer in dest_manifest.layers)
-        check_set = source_layers_digest & dest_layers_digest
-        self.assertListEqual(sorted(check_set), sorted(source_layers_digest))
+        n = len(source_manifest.layers)
+        self.assertListEqual(dest_manifest.layers[0:n], source_manifest.layers)
 
-        for digest in source_layers_digest:
+        # Ensure the blob files are copied to the destination image layout
+        for layer in source_manifest.layers:
+            digest = layer.descriptor["digest"]
             dest_blob = Path(dest_image.path, "blobs", *digest.split(":"))
             self.assertTrue(dest_blob.exists())
 

--- a/source-container-build/app/tox.ini
+++ b/source-container-build/app/tox.ini
@@ -3,7 +3,7 @@ env_list = flake8,black,test
 
 [testenv:test]
 deps = -r requirements-dev.txt
-commands = python3 -m pytest --cov=source_build --cov-report=term test_source_build.py
+commands = python3 -m pytest --cov=source_build --cov-report=term {posargs:.}
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
STONEBLD-2189

This commit introduces a new method to include parent sources into the
source container. During the build process, the parent sources as well
as metadata are copied to the built source container directly without
extraction and being built with other sources together by BSI. As a
result,

* Parent sources are appended to the source container and are kept in
  the same order as in the original source container.
* Config data .rootfs.diff_ids and .history are updated into the source
  container config.
* The sources layers are updated into the source container manifest
  along with the config updates.

Major changes:

* Source container build process is changed. Now, it is:
  * download parent sources
  * build source container with application source and prefetched
    sources
  * copy parent sources into the built source container
  * push to the registry
* Parent sources are not extracted to local for merge.
* sourceImageBuildDirectories.rpm_dir is used for gathering prefetched
  SRPMs. No parent sources are extracted into the directory referenced
  by it.
* Both prepare_base_image_sources and extract_blob_member are useless
  and deleted.
* New Python classes are introduced for manipulating the OCI image,
  which are specific to this commit. For detailed information about
  these classes, like Blob, Config and Manifest, please refer to the
  docstring in the code.

This PR also includes a few related refactors, please check the individual commit.