### PR TITLE
Fix SRPM collection

### DIFF
--- a/source-container-build/app/source_build.py
+++ b/source-container-build/app/source_build.py
@@ -244,10 +244,6 @@ def prepare_base_image_sources(
     )
     run(cmd, check=True)
 
-    # bsi reads source RPMs from this directory
-    bsi_rpms_dir = create_dir(base_image_sources_dir, "bsi_rpms_dir")
-    sib_dirs.rpm_dir = str(bsi_rpms_dir)  # save this directory for executing bsi
-
     # bsi reads extra sources from this directory
     # each source is in its own directory, for instance, subdir/source_a.tar.gz
     extra_src_dir = create_dir(base_sources_extraction_dir, "extra_src_dir")
@@ -449,7 +445,7 @@ def build_and_push(
 
     bsi_src_drivers = []
     bsi_cmd = [bsi_script, "-b", str(bsi_build_base_dir), "-o", str(image_output_dir)]
-    if sib_dirs.rpm_dir:
+    if sib_dirs.rpm_dir and os.listdir(sib_dirs.rpm_dir):
         bsi_src_drivers.append(BSI_DRV_RPM_DIR)
         bsi_cmd.append("-s")
         bsi_cmd.append(str(sib_dirs.rpm_dir))
@@ -561,7 +557,7 @@ def build(args) -> BuildResult:
     work_dir = create_dir(workspace_dir, "source-build")
     logger.debug("working directory %s", work_dir)
 
-    sib_dirs = SourceImageBuildDirectories()
+    sib_dirs = SourceImageBuildDirectories(rpm_dir=create_dir(work_dir, "bsi_rpms_dir"))
 
     make_source_archive(work_dir, args.source_dir, sib_dirs)
 

--- a/source-container-build/app/source_build.py
+++ b/source-container-build/app/source_build.py
@@ -204,21 +204,13 @@ def extract_blob_member(
     tar_archive: str, member: str, dest_dir: str, rename_to: str, work_dir: str, log: logging.Logger
 ) -> None:
     """Extract a blob member and rename it."""
-    # strip 3 components: ./blobs/sha256
-    tar_cmd = [
-        "tar",
-        "--extract",
-        "-C",
-        dest_dir,
-        "--strip-components",
-        "3",
-        "-f",
-        tar_archive,
-        member,
-    ]
-    log.debug("extract blob member %r", tar_cmd)
-    run(tar_cmd, check=True, cwd=work_dir)
-    shutil.move(f"{dest_dir}/{os.path.basename(member)}", f"{dest_dir}/{rename_to}")
+    log.debug("extract from %s/%s: %s -> %s/%s", work_dir, tar_archive, member, dest_dir, rename_to)
+    with tarfile.open(os.path.join(work_dir, tar_archive)) as tar:
+        content = tar.extractfile(member)
+        if not content:
+            raise ValueError(f"Could not etract {member} from {work_dir}/{tar_archive}")
+        with open(os.path.join(dest_dir, rename_to), "wb") as f:
+            shutil.copyfileobj(content, f)
 
 
 def prepare_base_image_sources(

--- a/source-container-build/app/test_source_build.py
+++ b/source-container-build/app/test_source_build.py
@@ -905,23 +905,23 @@ class TestBuildProcess(unittest.TestCase):
     def setUpClass(cls):
         cls.app_source_dirs = init_app_source_repo_dir()
 
-        cls.cachi2_dir = mkdtemp("-cachi2")
-        cachi2_output_dir = os.path.join(cls.cachi2_dir, "output")
-        os.mkdir(cachi2_output_dir)
-        create_fake_dep_packages(cachi2_output_dir, [os.path.join("pip", cls.PIP_PKG)])
-
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree(cls.cachi2_dir)
         shutil.rmtree(cls.app_source_dirs.root_dir)
 
     def setUp(self):
+        self.cachi2_dir = mkdtemp("-cachi2")
+        cachi2_output_dir = os.path.join(self.cachi2_dir, "output")
+        os.mkdir(cachi2_output_dir)
+        create_fake_dep_packages(cachi2_output_dir, [os.path.join("pip", self.PIP_PKG)])
+
         self.work_dir = mkdtemp("-test-build-process-work-dir")
         self.bsi = create_fake_bsi_bin()
         fd, self.result_file = mkstemp("-test-build-process-result-file")
         os.close(fd)
 
     def tearDown(self):
+        shutil.rmtree(self.cachi2_dir)
         shutil.rmtree(self.work_dir)
         os.unlink(self.bsi)
         os.unlink(self.result_file)
@@ -1200,12 +1200,9 @@ class TestBuildProcess(unittest.TestCase):
             cachi2_output_dir,
             {srpm_path: os.urandom(4)},
         )
-        try:
-            self._test_include_sources(
-                include_prefetched_sources=True, expect_prefetched_rpms_included=True
-            )
-        finally:
-            os.unlink(os.path.join(cachi2_output_dir, "deps", srpm_path))
+        self._test_include_sources(
+            include_prefetched_sources=True, expect_prefetched_rpms_included=True
+        )
 
     @patch("tarfile.open")
     def test_include_parent_image_sources(self, tarfile_open):


### PR DESCRIPTION
Previously, the sib_dirs.rpms_dir would only get initialized in
prepare_base_image_sources.

While processing prefetched SRPMs, if base image sources were not
processed, the rpms_dir would still be unset. The SRPMs would get copied
into os.path.join("", ...) (so somewhere in the current directory) and
the script would ignore all of them, because the condition for including
the rpms_dir is that sib_dirs.rpms_dir must be set.

Fix by always initializing rpms_dir at the beginning and changing the
condition from "rpms_dir must be set" to "rpms_dir must not be empty".