### PR TITLE
Match registries allow list by regex

### DIFF
--- a/source-container-build/app/source_build.py
+++ b/source-container-build/app/source_build.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from subprocess import run
 from tarfile import TarInfo
 from typing import Any, TypedDict, NotRequired, Literal, Final
-from urllib.parse import urlparse
 
 
 """
@@ -1013,7 +1012,8 @@ def build(args) -> BuildResult:
             logger.info("Multiple base images are specified: %r", base_images)
         base_image = base_images[-1]
 
-        allowed = urlparse("docker://" + base_image).netloc in args.registry_allowlist
+        allowed = any(re.match(allow_regex, base_image) for allow_regex in args.registry_allowlist)
+
         if allowed:
             source_image = resolve_source_image_by_version_release(
                 base_image

--- a/source-container-build/app/test_source_build.py
+++ b/source-container-build/app/test_source_build.py
@@ -30,6 +30,7 @@ REPO_NAME: Final = "sourcebuildapp"
 REGISTRY_ALLOWLIST: Final = """
 registry.example.io
 registry.access.example.com
+registry.io/user-workloads/
 """
 DISALLOWED_REGISTRY: Final = "registry.someone-hosted.io"
 
@@ -969,6 +970,12 @@ class TestBuildProcess(unittest.TestCase):
             parent_images="registry.access.example.com/ubi9/ubi:9.3-1@sha256:123\n",
             expect_parent_image_sources_included=True,
             source_image_is_resolved_by_version_release=False,
+        )
+
+    def test_not_include_parent_image_sources_due_to_org_is_not_matched(self):
+        self._test_include_sources(
+            parent_images="\ngolang:2\n\nregistry.io/ubi9/ubi:9.3-1@sha256:123\n",
+            expect_parent_image_sources_included=False,
         )
 
     @patch("source_build.run")


### PR DESCRIPTION
Related to STONEBLD-1831

Since this commit, the every line within the registries allow list are changed to regular expression. re.match is used for pattern matching, which causes the parent image reference is matched from the beginning. This is flexible for configuring the allow list to match more specifically.

This change is compatible with existing allow list. If necessary, the migration would be slight changes by converting "." to "\.".