### PR TITLE
Apply 0001-Use-extra-src-archive-checksum-in-filename.patch

### DIFF
--- a/source-container-build/0001-Use-extra-src-archive-checksum-in-filename.patch
+++ b/source-container-build/0001-Use-extra-src-archive-checksum-in-filename.patch
@@ -1,0 +1,61 @@
+From b39cfe6d4379a2c232288083b3387294b699e6f5 Mon Sep 17 00:00:00 2001
+From: Chenxiong Qi <cqi@redhat.com>
+Date: Wed, 24 Apr 2024 12:53:07 +0800
+Subject: [PATCH] Use extra-src archive checksum in filename
+
+There is a use case for source container images with extra sources. That is,
+after deduplicating sources between two images then merge them, same
+extra source tar archive names remain potentially.
+
+For instance, image A has extra-src-[012].tar archive per layer and
+image B has extra-src-[01].tar archive per layer. When extra-src-1.tar
+of image B duplicates the extra-src-2.tar of image A and is removed,
+then after merging these two images, the final source image will have
+two layers including extra-src-0.tar.
+
+As a result, if users extract the sources sequentially, previous
+extra-src-*.tar file may be overwritten.
+
+This patch replaces the counter with checksum computed from the extra
+source archive to avoid such potential duplicate. It is convenient for
+manipulate sources by image layers directly without the need of
+adjusting the counter.
+
+Signed-off-by: Chenxiong Qi <cqi@redhat.com>
+---
+ BuildSourceImage.sh | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/BuildSourceImage.sh b/BuildSourceImage.sh
+index ace5232..7bbd582 100755
+--- a/BuildSourceImage.sh
++++ b/BuildSourceImage.sh
+@@ -1030,19 +1030,21 @@ sourcedriver_extra_src_dir() {
+     local out_dir="${3}"
+     local manifest_dir="${4}"
+     local tarname
++    local tmptarname
+     local mimetype
+     local source_info
+-    local counter=0
+ 
+     for extra_src_dir in "${EXTRA_SRC_DIR_ARRAY[@]}"
+     do
+         _info "adding extra source directory $extra_src_dir"
+         _debug "$self: writing to $out_dir and $manifest_dir"
+-        tarname="extra-src-${counter}.tar"
+-        ((counter+=1))
++        tmptarname="extra-src.tar"
+         _tar -C "${extra_src_dir}" \
+             --sort=name --mtime=@0 --owner=0 --group=0 --mode='a+rw' --no-xattrs --no-selinux --no-acls \
+-            -cf "${out_dir}/${tarname}" .
++            -cf "${out_dir}/${tmptarname}" .
++        checksum=$(sha256sum "${out_dir}/${tmptarname}" | cut -d' ' -f1)
++        tarname="extra-src-${checksum}.tar"
++        mv "${out_dir}/${tmptarname}" "${out_dir}/${tarname}"
+         mimetype="$(file --brief --mime-type "${out_dir}"/"${tarname}")"
+         source_info="${manifest_dir}/${tarname}.json"
+         jq \
+-- 
+2.44.0
+

--- a/source-container-build/Dockerfile
+++ b/source-container-build/Dockerfile
@@ -4,16 +4,17 @@ ARG BSI_VERSION=0.2.0
 ARG bsi_source=https://github.com/containers/BuildSourceImage/archive/refs/tags/v${BSI_VERSION}.tar.gz
 ARG patch0=0001-cleanup-directory-with-all-rpms-which-isn-t-used-any.patch
 ARG patch1=0001-Increase-counter-as-numeric-rather-than-string.patch
+ARG patch2=0001-Use-extra-src-archive-checksum-in-filename.patch
 
 # hadolint ignore=DL3041
 RUN dnf update -y && dnf install -y python3.11 git jq skopeo file tar && dnf clean all
 
 WORKDIR /opt/BuildSourceImage
-COPY $patch0 $patch1 ./
+COPY $patch0 $patch1 $patch2 ./
 RUN curl -s -O -L $bsi_source && \
     tar --extract -f v${BSI_VERSION}.tar.gz -z --strip-components=1 BuildSourceImage-${BSI_VERSION}/BuildSourceImage.sh && \
-    git apply --allow-empty BuildSourceImage.sh $patch0 $patch1 && \
-    rm -r $patch0 $patch1 && \
+    git apply --allow-empty BuildSourceImage.sh $patch0 $patch1 $patch2 && \
+    rm -r $patch0 $patch1 $patch2 && \
     mv BuildSourceImage.sh bsi
 
 WORKDIR /opt/source_build/


### PR DESCRIPTION
Related to STONEBLD-1831

Remove this patch when upgrade BuildSourceImage to a newer version that includes this change.