### PR TITLE
fix: Provide insecure-policy option when copying source containers

### DIFF
--- a/source-container-build/app/test_source_build.py
+++ b/source-container-build/app/test_source_build.py
@@ -115,6 +115,7 @@ def create_skopeo_cli_parser() -> argparse.ArgumentParser:
     copy_parser = subparsers.add_parser("copy")
     copy_parser.add_argument("--digestfile", dest="digest_file")
     copy_parser.add_argument("--retry-times")
+    copy_parser.add_argument("--insecure-policy", action="store_true")
     copy_parser.add_argument("--remove-signatures", action="store_true")
     copy_parser.add_argument("src")
     copy_parser.add_argument("dest")


### PR DESCRIPTION
There's a bug in Red Hat production systems right now which is causing source containers to be published with no signatures:

* https://issues.redhat.com/browse/CLOUDDST-22731
* https://issues.redhat.com/browse/KFLUXBUGS-1267
* https://issues.redhat.com/browse/KFLUXBUGS-1268

We use those source containers as base images when constructing source containers for images built on Red Hat images. The absence of signatures is causing us to fail builds.

While those signatures are cleaned up, disable the policy check in skopeo to get builds moving again.

Consider, is this safe to apply? If we were faced with a similar situation where signatures were missing for binary images, we should not apply a workaround similar to this. Too risky. Source container images on the other hand are not a vector for attacking production systems.