### PR TITLE
Migrate build-definitions redhat-appstudio images

### DIFF
--- a/integration-tests/pipelines/e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-pipeline.yaml
@@ -24,7 +24,7 @@ spec:
             description: "custom bundle for source build pipeline"
         steps:
           - name: e2e-tests
-            image: quay.io/redhat-appstudio/appstudio-utils:18295e56febef33711ddf0229fdd57052bd12738
+            image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
             env:
             - name: SNAPSHOT
               value: $(params.SNAPSHOT)


### PR DESCRIPTION
STONEBLD-2339

All the images built in build-definitions CI now get released to the
quay.io/konflux-ci organization.

Replace the relevant redhat-appstudio[-tekton-catalog] references in
this repo with konflux-ci[/tekton-catalog] references.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
