### PR TITLE
icm-injection-scripts: Use /usr/share/buildinfo by default

### DIFF
--- a/icm-injection-scripts/scripts/inject-icm.sh
+++ b/icm-injection-scripts/scripts/inject-icm.sh
@@ -18,7 +18,9 @@ IMAGE="${1}"
 SQUASH="${SQUASH:-false}"
 
 icm_filename="content-sets.json"
-location="/root/buildinfo/content_manifests/${icm_filename}"
+# Note this used to be /root/buildinfo/content_manifests but is now /usr/share/buildinfo for compatibility
+# with bootc/ostree systems. Ref https://issues.redhat.com/browse/KONFLUX-6844
+location="/usr/share/buildinfo/${icm_filename}"
 
 if [ ! -f "./sbom-cachi2.json" ]; then
   echo "Could not find sbom-cachi2.json. No content_sets found for ICM"
@@ -68,7 +70,7 @@ echo "Constructed the following:"
 cat content-sets.json
 
 echo "Writing that to $location"
-buildah copy "$CONTAINER" content-sets.json /root/buildinfo/content_manifests/
+buildah copy "$CONTAINER" content-sets.json /usr/share/buildinfo/
 buildah config -a "org.opencontainers.image.base.name=${base_image_name}" -a "org.opencontainers.image.base.digest=${base_image_digest}" "$CONTAINER"
 
 BUILDAH_ARGS=()

--- a/icm-injection-scripts/scripts/test-inject-icm.sh
+++ b/icm-injection-scripts/scripts/test-inject-icm.sh
@@ -45,9 +45,9 @@ expect_icm=$(jq -n '{
   ]
 }')
 
-banner "Checking the content of /root/buildinfo/content_manifests/content-sets.json in $TEST_IMAGE"
+banner "Checking the content of /usr/share/buildinfo/content-sets.json in $TEST_IMAGE"
 
-got_icm=$(podman run --rm "$TEST_IMAGE" cat /root/buildinfo/content_manifests/content-sets.json | jq)
+got_icm=$(podman run --rm "$TEST_IMAGE" cat /usr/share/buildinfo/content-sets.json | jq)
 
 if [[ "$expect_icm" != "$got_icm" ]]; then
     printf "%s\n" \


### PR DESCRIPTION
Today this code writes to /root/buildinfo as a made up location from way back in the days of OSBS.

However, having this be in /root (/var/roothome) conflicts with bootc (RHEL Image Mode) that wants /var to start out as empty as possible in the container image (it acts as a volume/machine local state - https://containers.github.io/bootc/filesystem.html#var )

We actually hit this with RHEL CoreOS and introduced /usr/share/buildinfo - see https://github.com/coreos/coreos-assembler/commit/19531a6597eb4fc27beefea230002545e9a7cb11

And the scanners were taught to handle this (ref https://github.com/quay/claircore/commit/7250a059c82f019859e7493c3e2e452155da6164 )

This changes the script to just write to the /usr/share location by default, as it should still be compatible with scanners.

xref https://issues.redhat.com/browse/KONFLUX-6844