### PR TITLE
source-build: fix the name of the v0.2.0 artifact

### DIFF
--- a/source-container-build/Dockerfile
+++ b/source-container-build/Dockerfile
@@ -12,8 +12,8 @@ RUN dnf update -y && dnf install -y python3.11 git jq skopeo file tar && dnf cle
 
 WORKDIR /opt/BuildSourceImage
 COPY $patch0 $patch1 $patch2 $patch3 ./
-RUN cp /cachi2/output/deps/generic/v${BSI_VERSION}.tar.gz . && \
-    tar --extract -f v${BSI_VERSION}.tar.gz -z --strip-components=1 BuildSourceImage-${BSI_VERSION}/BuildSourceImage.sh && \
+RUN cp /cachi2/output/deps/generic/BuildSourceImage-${BSI_VERSION}.tar.gz . && \
+    tar --extract -f BuildSourceImage-${BSI_VERSION}.tar.gz -z --strip-components=1 BuildSourceImage-${BSI_VERSION}/BuildSourceImage.sh && \
     git apply --allow-empty BuildSourceImage.sh $patch0 $patch1 $patch2 $patch3 && \
     rm -r $patch0 $patch1 $patch2 $patch3 && \
     mv BuildSourceImage.sh bsi

--- a/source-container-build/artifacts.lock.yaml
+++ b/source-container-build/artifacts.lock.yaml
@@ -3,4 +3,4 @@ metadata:
 artifacts:
   - download_url: "https://github.com/containers/BuildSourceImage/archive/refs/tags/v0.2.0.tar.gz"
     checksum: "sha256:e770a8c7e77f821f8d842312aa1bca7dd869debf8a31f5fa1af28f6c494e0529"
-    filename: "v0.2.0.tar.gz"
+    filename: "BuildSourceImage-0.2.0.tar.gz"


### PR DESCRIPTION
Name it BuildSourceImage-0.2.0 to:

1. better describe what it is
2. match the name that is expected in our downstream Conforma policy