### PR TITLE
Add .codecov.yml for coverage tracking compliance

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,19 @@
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true
+
+comment:
+  layout: "header, diff, flags, components"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Summary

Part of the org-wide Codecov rollout ([KFLUXDP-1020](https://issues.redhat.com/browse/KFLUXDP-1020)).

Adds `.codecov.yml` with informational coverage checks:
- **Project coverage**: tracks current baseline (`auto`) with 1% allowed drop
- **Patch coverage**: 80% target for new/changed lines
- All checks are **informational** (non-blocking) — they won't fail CI or block merges

This provides visibility into coverage trends without disrupting existing workflows.

## Test plan
- [x] Config follows standard org template
- [ ] Verify Codecov reports appear on subsequent PRs

Signed-off-by: Eyal Edri <eedri@redhat.com>

[KFLUXDP-1020]: https://redhat.atlassian.net/browse/KFLUXDP-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ